### PR TITLE
Improved button embed extension

### DIFF
--- a/Sources/SwiftUI-Kit/Extensions/View+Embed.swift
+++ b/Sources/SwiftUI-Kit/Extensions/View+Embed.swift
@@ -62,6 +62,7 @@ public extension View {
     
     func embedInPlainButton(action: @escaping () -> Void) -> some View {
         Button(action: action, label: { self })
+            .contentShape(Rectangle())
             .buttonStyle(.plain)
     }
 }


### PR DESCRIPTION
Added content shape to a plain button, to aviod any situations where the button has not full content tappability
<img width="1211" alt="Screenshot 2024-08-10 at 22 04 24" src="https://github.com/user-attachments/assets/1e2a70dd-b8de-4e9b-83c9-f032f653bda6">


https://github.com/user-attachments/assets/16ba7dc3-0ce1-47ba-ac2c-44800befa0e1

