### PR TITLE
Moved contentshape to the label itself on embedinplainbutton

### DIFF
--- a/Sources/SwiftUI-Kit/Extensions/View+Embed.swift
+++ b/Sources/SwiftUI-Kit/Extensions/View+Embed.swift
@@ -61,8 +61,12 @@ public extension View {
     }
     
     func embedInPlainButton(action: @escaping () -> Void) -> some View {
-        Button(action: action, label: { self })
-            .contentShape(Rectangle())
-            .buttonStyle(.plain)
+        Button(
+            action: action,
+            label: {
+                self.contentShape(Rectangle())
+            }
+        )
+        .buttonStyle(.plain)
     }
 }


### PR DESCRIPTION
Problem:
The tappability was okay for single-item labels like text or image, but didn't work for stacks.

Solution:
Moved contentshape to the label itself, to cover tappability for more complex labels