### PR TITLE
Add parameter overloads to .read modifier

### DIFF
--- a/Sources/SwiftUI-Kit/Extensions/View.swift
+++ b/Sources/SwiftUI-Kit/Extensions/View.swift
@@ -449,20 +449,20 @@ public struct OffsetPreferenceKey: PreferenceKey {
     }
 }
 
-public struct SizePreferenceKey: PreferenceKey {
-    public static var defaultValue: CGSize = .zero
-
-    /// A function that updates the preference value with the next value.
-    public static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
-        value = nextValue()
-    }
-}
-
 public struct RectPreferenceKey: PreferenceKey {
     public static var defaultValue: CGRect = .zero
 
     /// A function that updates the preference value with the next value.
     public static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
+        value = nextValue()
+    }
+}
+
+public struct SizePreferenceKey: PreferenceKey {
+    public static var defaultValue: CGSize = .zero
+
+    /// A function that updates the preference value with the next value.
+    public static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
         value = nextValue()
     }
 }

--- a/Sources/SwiftUI-Kit/Extensions/View.swift
+++ b/Sources/SwiftUI-Kit/Extensions/View.swift
@@ -342,48 +342,7 @@ public extension View {
     }
 }
 
-// MARK: Offset
-public extension View {
-    /// Tracks the offset of the current view within the specified coordinate space.
-    ///
-    /// This method adds an overlay using `GeometryReader` to compute the `minY` offset of the view within the given coordinate space. The
-    /// offset value is then passed to the provided completion handler.
-    ///
-    /// - Parameters:
-    ///   - coordinateSpace: The `CoordinateSpace` in which the view's position is to be measured.
-    ///   - completion: A closure that receives the computed `minY` offset value.
-    /// - Returns: A modified `View` that provides the offset value of its position within the specified coordinate space.
-    @available(iOS 15.0, *)
-    func offset(
-        coordinateSpace: CoordinateSpace,
-        completion: @escaping (CGFloat) -> Void
-    ) -> some View {
-        overlay {
-            GeometryReader { proxy in
-                let minY = proxy.frame(in: coordinateSpace).minY
-                Color.clear
-                    .preference(key: OffsetPreferenceKey.self, value: minY)
-                    .onPreferenceChange(OffsetPreferenceKey.self) { value in
-                        completion(value)
-                    }
-            }
-        }
-    }
-
-    /// Reads the initial size of the view and assigns it to the provided binding.
-    /// - Parameter size: A binding to store the view’s initial size (only on first appearance).
-    /// - Returns: A view that captures its size using `GeometryReader` and sets it once on appear.
-    func readInitial(_ size: Binding<CGSize>) -> some View {
-        background(
-            GeometryReader { geometry in
-                Color.white.opacity(0.000001)
-                    .onAppear { size.wrappedValue = geometry.size }
-            }
-        )
-    }
-}
-
-// MARK: Read
+// MARK: Read & Offset
 extension View {
     /// Reads the center point of the view and binds it to a `CGPoint`.
     ///
@@ -419,6 +378,29 @@ extension View {
         read(in: coordinateSpace, animation: animation) { newValue in
             rect.wrappedValue = newValue
         }
+    }
+    
+    /// Tracks the offset of the current view within the specified coordinate space.
+    ///
+    /// - Parameters:
+    ///   - coordinateSpace: The `CoordinateSpace` in which the view's position is to be measured.
+    ///   - completion: A closure that receives the computed `minY` offset value.
+    public func offset(coordinateSpace: CoordinateSpace, completion: @escaping (CGFloat) -> Void, animation: Animation? = nil) -> some View {
+        read(in: coordinateSpace, animation: animation) { newValue in
+            completion(newValue.minY)
+        }
+    }
+    
+    /// Reads the initial size of the view and assigns it to the provided binding.
+    /// - Parameter size: A binding to store the view’s initial size (only on first appearance).
+    /// - Returns: A view that captures its size using `GeometryReader` and sets it once on appear.
+    public func readInitial(_ size: Binding<CGSize>) -> some View {
+        background(
+            GeometryReader { geometry in
+                Color.white.opacity(0.000001)
+                    .onAppear { size.wrappedValue = geometry.size }
+            }
+        )
     }
     
     @ViewBuilder
@@ -463,6 +445,15 @@ public struct OffsetPreferenceKey: PreferenceKey {
     public static var defaultValue: CGFloat = .zero
 
     public static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
+public struct SizePreferenceKey: PreferenceKey {
+    public static var defaultValue: CGSize = .zero
+
+    /// A function that updates the preference value with the next value.
+    public static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
         value = nextValue()
     }
 }

--- a/Sources/SwiftUI-Kit/Extensions/View.swift
+++ b/Sources/SwiftUI-Kit/Extensions/View.swift
@@ -342,29 +342,8 @@ public extension View {
     }
 }
 
-// MARK: Read & Offset
+// MARK: Offset
 public extension View {
-    /// Reads the position of a view within a specified coordinate space and updates the provided binding with the calculated position.
-    /// - Parameters:
-    ///   - position: A binding to a `CGPoint` that will be updated with the view's position.
-    ///   - coordinateSpace: The `CoordinateSpace` in which the view's position should be measured.
-    /// - Returns: A view that reads its position and updates the binding accordingly.
-    @available(iOS 15.0, *)
-    func read(_ position: Binding<CGPoint>, in coordinateSpace: CoordinateSpace) -> some View {
-        background {
-            GeometryReader { geometry in
-                // Using a nearly invisible background to trigger the GeometryReader
-                Color.white.opacity(0.000001)
-                    .preference(key: RectPreferenceKey.self, value: geometry.frame(in: coordinateSpace))
-                    .onPreferenceChange(RectPreferenceKey.self) { frame in
-                        withAnimation {
-                            position.wrappedValue = .init(x: frame.midX, y: frame.midY)
-                        }
-                    }
-            }
-        }
-    }
-
     /// Tracks the offset of the current view within the specified coordinate space.
     ///
     /// This method adds an overlay using `GeometryReader` to compute the `minY` offset of the view within the given coordinate space. The
@@ -391,28 +370,6 @@ public extension View {
         }
     }
 
-    /// Reads the size of a view and updates the provided binding with the calculated size.
-    ///
-    /// This method uses a `GeometryReader` placed in the background to measure the view’s size.
-    /// The size is then passed to the specified `Binding<CGSize>`, allowing external state to react
-    /// to layout changes or dynamic sizing.
-    ///
-    /// - Parameter size: A binding to a `CGSize` that will be updated with the view's current size.
-    /// - Returns: A view that measures its own size and updates the binding accordingly.
-    func read(_ size: Binding<CGSize>) -> some View {
-        background(
-            GeometryReader { geometry in
-                Color.white.opacity(0.000001)
-                    .preference(key: SizePreferenceKey.self, value: geometry.size)
-                    .onPreferenceChange(SizePreferenceKey.self) { newSize in
-                        withAnimation {
-                            size.wrappedValue = newSize
-                        }
-                    }
-            }
-        )
-    }
-
     /// Reads the initial size of the view and assigns it to the provided binding.
     /// - Parameter size: A binding to store the view’s initial size (only on first appearance).
     /// - Returns: A view that captures its size using `GeometryReader` and sets it once on appear.
@@ -425,6 +382,82 @@ public extension View {
         )
     }
 }
+
+// MARK: Read
+extension View {
+    /// Reads the center point of the view and binds it to a `CGPoint`.
+    ///
+    /// - Parameters:
+    ///   - position: A binding to a `CGPoint` that will be updated with the view's center.
+    ///   - coordinateSpace: The coordinate space in which to measure the position. Defaults to `.global`.
+    ///   - animation: An optional animation to apply when the position changes. Defaults to `nil`.
+    public func read(_ position: Binding<CGPoint>, in coordinateSpace: CoordinateSpace = .global, animation: Animation? = nil) -> some View {
+        read(in: coordinateSpace, animation: animation) { rect in
+            position.wrappedValue = CGPoint(x: rect.midX, y: rect.midY)
+        }
+    }
+    
+    /// Reads the full frame of the view and binds it to a `CGRect`
+    ///
+    /// - Parameters:
+    ///   - rect: A binding to a `CGRect` that will be updated with the view's frame.
+    ///   - coordinateSpace: The coordinate space in which to measure the position. Defaults to `.global`.
+    ///   - animation: An optional animation to apply when the position changes. Defaults to `nil`.
+    public func read(_ size: Binding<CGSize>, in coordinateSpace: CoordinateSpace = .global, animation: Animation? = nil) -> some View {
+        read(in: coordinateSpace, animation: animation) { rect in
+            size.wrappedValue = rect.size
+        }
+    }
+    
+    /// Reads the size of the view and binds it to a `CGSize`.
+    ///
+    /// - Parameters:
+    ///   - size: A binding to a `CGSize` that will be updated with the view's dimensions.
+    ///   - coordinateSpace: The coordinate space in which to measure the position. Defaults to `.global`.
+    ///   - animation: An optional animation to apply when the position changes. Defaults to `nil`.
+    public func read(_ rect: Binding<CGRect>, in coordinateSpace: CoordinateSpace = .global, animation: Animation? = nil) -> some View {
+        read(in: coordinateSpace, animation: animation) { newValue in
+            rect.wrappedValue = newValue
+        }
+    }
+    
+    @ViewBuilder
+    private func read(in coordinateSpace: CoordinateSpace, animation: Animation?, action: @escaping (CGRect) -> Void) -> some View {
+        if #available(iOS 16.0, *) {
+            readGeometry(in: coordinateSpace, animation: animation, action: action)
+        } else {
+            readLegacy(in: coordinateSpace, animation: animation, action: action)
+        }
+    }
+    
+    
+    @available(iOS 16.0, *)
+    private func readGeometry(in coordinateSpace: CoordinateSpace, animation: Animation?, action: @escaping (CGRect) -> Void) -> some View {
+        onGeometryChange(for: CGRect.self) { proxy in
+            proxy.frame(in: coordinateSpace)
+        } action: { newValue in
+            withAnimation(animation) {
+                action(newValue)
+            }
+        }
+    }
+    
+    private func readLegacy(in coordinateSpace: CoordinateSpace, animation: Animation?, action: @escaping (CGRect) -> Void) -> some View {
+        background(
+            GeometryReader { geometry in
+                Color.white.opacity(0.000001)
+                    .preference(key: RectPreferenceKey.self, value: geometry.frame(in: coordinateSpace))
+                    .onPreferenceChange(RectPreferenceKey.self) { newRect in
+                        withAnimation(animation) {
+                            action(newRect)
+                        }
+                    }
+            }
+        )
+    }
+}
+
+
 
 public struct OffsetPreferenceKey: PreferenceKey {
     public static var defaultValue: CGFloat = .zero
@@ -439,15 +472,6 @@ public struct RectPreferenceKey: PreferenceKey {
 
     /// A function that updates the preference value with the next value.
     public static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
-        value = nextValue()
-    }
-}
-
-public struct SizePreferenceKey: PreferenceKey {
-    public static var defaultValue: CGSize = .zero
-
-    /// A function that updates the preference value with the next value.
-    public static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
         value = nextValue()
     }
 }

--- a/Sources/SwiftUI-Kit/Extensions/View.swift
+++ b/Sources/SwiftUI-Kit/Extensions/View.swift
@@ -356,10 +356,10 @@ extension View {
         }
     }
     
-    /// Reads the full frame of the view and binds it to a `CGRect`
+    /// Reads the size of the view and binds it to a `CGSize`.
     ///
     /// - Parameters:
-    ///   - rect: A binding to a `CGRect` that will be updated with the view's frame.
+    ///   - size: A binding to a `CGSize` that will be updated with the view's dimensions.
     ///   - coordinateSpace: The coordinate space in which to measure the position. Defaults to `.global`.
     ///   - animation: An optional animation to apply when the position changes. Defaults to `nil`.
     public func read(_ size: Binding<CGSize>, in coordinateSpace: CoordinateSpace = .global, animation: Animation? = nil) -> some View {
@@ -368,10 +368,10 @@ extension View {
         }
     }
     
-    /// Reads the size of the view and binds it to a `CGSize`.
+    /// Reads the full frame of the view and binds it to a `CGRect`
     ///
     /// - Parameters:
-    ///   - size: A binding to a `CGSize` that will be updated with the view's dimensions.
+    ///   - rect: A binding to a `CGRect` that will be updated with the view's frame.
     ///   - coordinateSpace: The coordinate space in which to measure the position. Defaults to `.global`.
     ///   - animation: An optional animation to apply when the position changes. Defaults to `nil`.
     public func read(_ rect: Binding<CGRect>, in coordinateSpace: CoordinateSpace = .global, animation: Animation? = nil) -> some View {

--- a/Sources/SwiftUI-Kit/Extensions/View.swift
+++ b/Sources/SwiftUI-Kit/Extensions/View.swift
@@ -404,7 +404,7 @@ extension View {
     }
     
     @ViewBuilder
-    private func read(in coordinateSpace: CoordinateSpace, animation: Animation?, action: @escaping (CGRect) -> Void) -> some View {
+    private func read(in coordinateSpace: CoordinateSpace, animation: Animation? = nil, action: @escaping (CGRect) -> Void) -> some View {
         if #available(iOS 16.0, *) {
             readGeometry(in: coordinateSpace, animation: animation, action: action)
         } else {
@@ -414,7 +414,7 @@ extension View {
     
     
     @available(iOS 16.0, *)
-    private func readGeometry(in coordinateSpace: CoordinateSpace, animation: Animation?, action: @escaping (CGRect) -> Void) -> some View {
+    private func readGeometry(in coordinateSpace: CoordinateSpace, animation: Animation? = nil, action: @escaping (CGRect) -> Void) -> some View {
         onGeometryChange(for: CGRect.self) { proxy in
             proxy.frame(in: coordinateSpace)
         } action: { newValue in
@@ -424,7 +424,7 @@ extension View {
         }
     }
     
-    private func readLegacy(in coordinateSpace: CoordinateSpace, animation: Animation?, action: @escaping (CGRect) -> Void) -> some View {
+    private func readLegacy(in coordinateSpace: CoordinateSpace, animation: Animation? = nil, action: @escaping (CGRect) -> Void) -> some View {
         background(
             GeometryReader { geometry in
                 Color.white.opacity(0.000001)


### PR DESCRIPTION
1. Add support for onGeometryChange on iOS 17+ while falling back to the legacy approach for older versions;
2. Provide .read modifier overloads for CGRect, CGPoint, CGSize;
3. Add the ability to control animations when the target frame changes.